### PR TITLE
Provide guidance on renaming a fork #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Researchers and organizations publishing data in the [EDI Repository](https://po
 
 To see an example of how to embed the catalog in a web page `<iframe>`, view the page source code of the [Jornada Basin LTER Data Catalog](https://lter.jornada.nmsu.edu/data-catalog/) or experiment using the W3Schools [HTML Tryit editor](https://www.w3schools.com/html/tryit.asp?filename=tryhtml_intro).
 
+_Note: If you decide to rename your fork of ezCatalog, you will need to update both the iframe code snippet and live demo hyperlink with the new repository name._
+
 ## Features
 
 ### Autocomplete


### PR DESCRIPTION
If a user renames their fork of ezCatalog, both the iframe snippet for embedding in a web page and the live demo link at the top of the README will reference non-existant resources.

This commit provides guidance on how to handle this use case.